### PR TITLE
feat: pipe stream on fs write

### DIFF
--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -37,24 +37,12 @@ module.exports = {
       });
 
       const socketPromise = new Promise((resolve, reject) => {
-        if (pipeAllowed) {
-          this.connector.socket.pipe(stream);
-        } else { 
-          this.connector.socket.on('data', (data) => {
-            if (this.connector.socket) this.connector.socket.pause();
-            if (stream && stream.writable) {
-              stream.write(data, () => { 
-                this.connector.socket && this.connector.socket.resume();
-              });
-            }
-          });
-       
-          this.connector.socket.once('end', () => {
-            if (stream.listenerCount('close')) stream.emit('close');
-            else stream.end();
-            resolve();
-          });
-        }
+        this.connector.socket.pipe(stream, {end: false});
+        this.connector.socket.once('end', () => {
+          if (stream.listenerCount('close')) stream.emit('close');
+          else stream.end();
+          resolve();
+        });
         this.connector.socket.once('error', destroyConnection(stream, reject));
       });
 

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -37,21 +37,24 @@ module.exports = {
       });
 
       const socketPromise = new Promise((resolve, reject) => {
-        if (pipeAllowed) this.connector.socket.pipe(stream);
-        else  this.connector.socket.on('data', (data) => {
-                if (this.connector.socket) this.connector.socket.pause();
-                if (stream && stream.writable) {
-                  stream.write(data, () => { 
-                    this.connector.socket && this.connector.socket.resume();
-                  });
-                }
+        if (pipeAllowed) {
+          this.connector.socket.pipe(stream);
+        } else { 
+          this.connector.socket.on('data', (data) => {
+            if (this.connector.socket) this.connector.socket.pause();
+            if (stream && stream.writable) {
+              stream.write(data, () => { 
+                this.connector.socket && this.connector.socket.resume();
               });
+            }
+          });
        
-              this.connector.socket.once('end', () => {
-                if (stream.listenerCount('close')) stream.emit('close');
-                else stream.end();
-                resolve();
-              });
+          this.connector.socket.once('end', () => {
+            if (stream.listenerCount('close')) stream.emit('close');
+            else stream.end();
+            resolve();
+          });
+        }
         this.connector.socket.once('error', destroyConnection(stream, reject));
       });
 

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -13,7 +13,7 @@ module.exports = {
     .tap(() => this.commandSocket.pause())
     .then(() => Promise.try(() => this.fs.write(fileName, {append, start: this.restByteCount})))
     .then((fsResponse) => {
-      let {stream, clientPath, allowPipe} = fsResponse;
+      let {stream, clientPath, pipeAllowed} = fsResponse;
       if (!stream && !clientPath) {
         stream = fsResponse;
         clientPath = fileName;
@@ -37,7 +37,7 @@ module.exports = {
       });
 
       const socketPromise = new Promise((resolve, reject) => {
-        if (allowPipe) this.connector.socket.pipe(stream);
+        if (pipeAllowed) this.connector.socket.pipe(stream);
         else  this.connector.socket.on('data', (data) => {
                 if (this.connector.socket) this.connector.socket.pause();
                 if (stream && stream.writable) {

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -13,7 +13,7 @@ module.exports = {
     .tap(() => this.commandSocket.pause())
     .then(() => Promise.try(() => this.fs.write(fileName, {append, start: this.restByteCount})))
     .then((fsResponse) => {
-      let {stream, clientPath, pipeAllowed} = fsResponse;
+      let {stream, clientPath } = fsResponse;
       if (!stream && !clientPath) {
         stream = fsResponse;
         clientPath = fileName;

--- a/src/commands/registration/stor.js
+++ b/src/commands/registration/stor.js
@@ -13,7 +13,7 @@ module.exports = {
     .tap(() => this.commandSocket.pause())
     .then(() => Promise.try(() => this.fs.write(fileName, {append, start: this.restByteCount})))
     .then((fsResponse) => {
-      let {stream, clientPath } = fsResponse;
+      let {stream, clientPath} = fsResponse;
       if (!stream && !clientPath) {
         stream = fsResponse;
         clientPath = fileName;


### PR DESCRIPTION
This PR aim is to make socket pipe method available on `FTP` command `STOR` , in order to support other methods and make it more versatile to support other npm packages like `s3fs`. because of an issue to write the stream directly to `AWS S3`, i decided to allow pipe method on `STOR` command. That may help you to come up with a better solution. also, there was a problem on `sockt.resume` function, which triggers error, if it does not exist probably because the socket is closed. 

Thanks 