### PR TITLE
fix: dns lookup fail with IP with zeros padding

### DIFF
--- a/src/commands/registration/port.js
+++ b/src/commands/registration/port.js
@@ -9,7 +9,7 @@ module.exports = {
     const rawConnection = _.get(command, 'arg', '').split(',');
     if (rawConnection.length !== 6) return this.reply(425);
 
-    const ip = rawConnection.slice(0, 4).join('.');
+    const ip = rawConnection.slice(0, 4).map((b) => parseInt(b)).join('.');
     const portBytes = rawConnection.slice(4).map((p) => parseInt(p));
     const port = portBytes[0] * 256 + portBytes[1];
 


### PR DESCRIPTION
Some hardware devices are passing IP address with zeroes padding (e.g 192.168.001.103) to PORT command.
That causes DNS lookup failure on Windows hosts.

```
error: Error: getaddrinfo ENOTFOUND 192.168.001.103
       at GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:66:26) {
     errno: 'ENOTFOUND',
     code: 'ENOTFOUND',
     syscall: 'getaddrinfo',
     hostname: '192.168.001.103'
   }```