### PR TITLE
fix(feat): lazy require registry 

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "scripts": {
     "pre-release": "npm run verify",
-    "test": "mocha test/**/*.spec.js test/*.spec.js --ui bdd",
+    "test": "mocha test/*/*/*.spec.js test/*/*.spec.js test/*.spec.js",
     "verify": "eslint src/**/*.js test/**/*.js bin/**/*.js"
   },
   "release": {

--- a/src/commands/registration/feat.js
+++ b/src/commands/registration/feat.js
@@ -1,9 +1,9 @@
 const _ = require('lodash');
-const registry = require('../registry');
 
 module.exports = {
   directive: 'FEAT',
   handler: function () {
+    const registry = require('../registry');
     const features = Object.keys(registry)
       .reduce((feats, cmd) => {
         const feat = _.get(registry[cmd], 'flags.feat', null);

--- a/test/commands/registration/feat.spec.js
+++ b/test/commands/registration/feat.spec.js
@@ -1,0 +1,29 @@
+const Promise = require('bluebird');
+const {expect} = require('chai');
+const sinon = require('sinon');
+
+const CMD = 'FEAT';
+describe(CMD, function () {
+  let sandbox;
+  const mockClient = {
+    reply: () => Promise.resolve()
+  };
+  const cmdFn = require(`../../../src/commands/registration/${CMD.toLowerCase()}`).handler.bind(mockClient);
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create().usingPromise(Promise);
+
+    sandbox.spy(mockClient, 'reply');
+  });
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('// successful', () => {
+    return cmdFn({command: {directive: CMD}})
+    .then(() => {
+      expect(mockClient.reply.args[0][0]).to.equal(211);
+      expect(mockClient.reply.args[0][2].message).to.equal(' AUTH TLS');
+    });
+  });
+});


### PR DESCRIPTION
If requiring the registry from the module scope the result is an empty object. I assume this is caused by the circular nature of this dep.

Takes the core fix from https://github.com/autovance/ftp-srv/pull/234 (thank you!)