### PR TITLE
feat: allow dynamic pasv_url depending on remote address

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,14 +75,14 @@ __Default:__ `"ftp://127.0.0.1:21"`
 #### `pasv_url`
 `FTP-srv` provides an IP address to the client when a `PASV` command is received in the handshake for a passive connection. Reference [PASV verb](https://cr.yp.to/ftp/retr.html#pasv). This can be one of two options:
 - A function which takes one parameter containing the remote IP address of the FTP client. This can be useful when the user wants to return a different IP address depending if the user is connecting from Internet or from an LAN address.
- ```
+ ```js
 const {Netmask} = require('netmask');
 const networks = {
   '$GATEWAY_IP/32': `${public_ip}`, 
   '10.0.0.0/8'    : `${lan_ip}`
 } 
 
-address => {
+const resolverFunction = (address) => {
     for (const network in networks) {
         try {
             const mask = new Netmask(network);
@@ -94,7 +94,8 @@ address => {
     }
     return '127.0.0.1';
 }
-```
+
+new FtpSrv({pasv_url: resolverFunction});
 
 - A static IP address (ie. an external WAN **IP address** that the FTP server is bound to). In this case, only connections from localhost are handled differently returning `127.0.0.1` to the client. 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,31 @@ _Note:_ The hostname must be the external IP address to accept external connecti
 __Default:__ `"ftp://127.0.0.1:21"`
 
 #### `pasv_url`
-This **must** be the external WAN **IP address** that the FTP server is bound to. `FTP-srv` provides this IP address to the client when a `PASV` command is received in the handshake for a passive connection. Reference [PASV verb](https://cr.yp.to/ftp/retr.html#pasv).
+`FTP-srv` provides an IP address to the client when a `PASV` command is received in the handshake for a passive connection. Reference [PASV verb](https://cr.yp.to/ftp/retr.html#pasv). This can be one of two options:
+- A function which takes one parameter containing the remote IP address of the FTP client. This can be useful when the user wants to return a different IP address depending if the user is connecting from Internet or from an LAN address.
+ ```
+const {Netmask} = require('netmask');
+const networks = {
+  '$GATEWAY_IP/32': `${public_ip}`, 
+  '10.0.0.0/8'    : `${lan_ip}`
+} 
+
+address => {
+    for (const network in networks) {
+        try {
+            const mask = new Netmask(network);
+            if (mask.contains(address)) return networks[network];
+        }
+        catch (err) {
+            logger.error('Error checking source network', err);
+        }
+    }
+    return '127.0.0.1';
+}
+```
+
+- A static IP address (ie. an external WAN **IP address** that the FTP server is bound to). In this case, only connections from localhost are handled differently returning `127.0.0.1` to the client. 
+
 If not provided, clients can only connect using an `Active` connection.
 
 #### `pasv_min`

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ const resolverFunction = (address) => {
 }
 
 new FtpSrv({pasv_url: resolverFunction});
-
 - A static IP address (ie. an external WAN **IP address** that the FTP server is bound to). In this case, only connections from localhost are handled differently returning `127.0.0.1` to the client. 
 
 If not provided, clients can only connect using an `Active` connection.

--- a/src/commands/registration/pasv.js
+++ b/src/commands/registration/pasv.js
@@ -8,15 +8,18 @@ module.exports = {
       return this.reply(502);
     }
 
+    let port;
     this.connector = new PassiveConnector(this);
     return this.connector.setupServer()
     .then((server) => {
-      let address = this.server.options.pasv_url;
+      port = server.address();
       // Allow connecting from local
-      if (isLocalIP(this.ip)) {
-        address = this.ip;
-      }
-      const {port} = server.address();
+      if (isLocalIP(this.ip)) return this.ip;
+      let address = this.server.options.pasv_url;
+      if (typeof address === "function") return address(this.commandSocket.remoteAddress);
+      return address;
+    })
+    .then((address) => {
       const host = address.replace(/\./g, ',');
       const portByte1 = port / 256 | 0;
       const portByte2 = port % 256;

--- a/src/commands/registration/pasv.js
+++ b/src/commands/registration/pasv.js
@@ -21,7 +21,7 @@ module.exports = {
       if (isLocalIP(this.ip)) pasvAddress = this.ip;
       return {address: pasvAddress, port};
     })
-    .then((address, port) => {
+    .then(({address, port}) => {
       const host = address.replace(/\./g, ',');
       const portByte1 = port / 256 | 0;
       const portByte2 = port % 256;

--- a/src/commands/registration/pasv.js
+++ b/src/commands/registration/pasv.js
@@ -12,7 +12,7 @@ module.exports = {
     this.connector = new PassiveConnector(this);
     return this.connector.setupServer()
     .then((server) => {
-      port = server.address();
+      port = server.address().port;
       // Allow connecting from local
       if (isLocalIP(this.ip)) return this.ip;
       let address = this.server.options.pasv_url;

--- a/src/commands/registration/pasv.js
+++ b/src/commands/registration/pasv.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 const PassiveConnector = require('../../connector/passive');
 const {isLocalIP} = require('../../helpers/is-local');
 

--- a/src/commands/registration/pasv.js
+++ b/src/commands/registration/pasv.js
@@ -16,7 +16,7 @@ module.exports = {
       // Allow connecting from local
       if (isLocalIP(this.ip)) return this.ip;
       let address = this.server.options.pasv_url;
-      if (typeof address === "function") return address(this.commandSocket.remoteAddress);
+      if (typeof address === "function") return address(this.ip);
       return address;
     })
     .then((address) => {


### PR DESCRIPTION
Allow passing a function to pasv_url with the remote IP of the client, so that we can flexibly decide what is the correct passive URL to use. Useful if we want an FTP to be used from different networks (Intranet and internet for example)