### PR TITLE
chore: make fileName available in getUniqueName

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,8 @@ __Used in:__ `RNFR`, `RNTO`
 Modifies a file or directory's permissions  
 __Used in:__ `SITE CHMOD`
 
-#### [`getUniqueName()`](src/fs.js#L131)
-Returns a unique file name to write to  
+#### [`getUniqueName(fileName)`](src/fs.js#L131)
+Returns a unique file name to write to. Client requested filename available if you want to base your function on it. 
 __Used in:__ `STOU`
 
 ## Contributing

--- a/ftp-srv.d.ts
+++ b/ftp-srv.d.ts
@@ -38,7 +38,7 @@ export class FileSystem {
 
     chmod(path: string, mode: string): Promise<any>;
 
-    getUniqueName(): string;
+    getUniqueName(fileName: string): string;
 }
 
 export class FtpConnection extends EventEmitter {

--- a/src/commands/registration/stou.js
+++ b/src/commands/registration/stou.js
@@ -9,7 +9,7 @@ module.exports = {
 
     const fileName = args.command.arg;
     return Promise.try(() => this.fs.get(fileName))
-    .then(() => Promise.try(() => this.fs.getUniqueName()))
+    .then(() => Promise.try(() => this.fs.getUniqueName(fileName)))
     .catch(() => fileName)
     .then((name) => {
       args.command.arg = name;


### PR DESCRIPTION
Make client requested fileName available on getUniqueName function, to be used optionally if you want for example to use temp filenames adding some suffix on the original name.